### PR TITLE
Add Jest test for parseMarkdown

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm test

--- a/blog.js
+++ b/blog.js
@@ -74,7 +74,7 @@ function parseMarkdown(content, filename) {
         date: data.date || new Date().toISOString(),
         featured_image: data.featured_image,
         tags: data.tags ? data.tags.split(',').map(t => t.trim()) : [],
-        draft: data.draft === 'true',
+        draft: String(data.draft).toLowerCase() === 'true',
         body: body.trim(),
         excerpt: body.trim().substring(0, 150) + '...'
     };
@@ -124,7 +124,13 @@ function formatDate(dateString) {
 }
 
 // Load blog posts when page loads
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('Page loaded, initializing blog...');
-    loadBlogPosts();
-});
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', function() {
+        console.log('Page loaded, initializing blog...');
+        loadBlogPosts();
+    });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { parseMarkdown };
+}

--- a/functions/blog/[slug].js
+++ b/functions/blog/[slug].js
@@ -1,37 +1,42 @@
 // functions/blog/[slug].js
 export async function onRequest(context) {
-  const { params, request, env } = context;
+  const { params, request } = context;
   let slug = params.slug;
-  
+
   // Remove .html extension if present
   if (slug && slug.endsWith('.html')) {
     slug = slug.replace('.html', '');
   }
-  
+
+  // Redirect common index slugs to the blog list
+  if (slug === 'blog-index' || slug === 'index') {
+    return Response.redirect('/blog/', 302);
+  }
+
   console.log('Blog function called with slug:', slug);
-  
+
   try {
     // Get the blog-post.html template
     const baseUrl = new URL(request.url).origin;
     const templateResponse = await fetch(`${baseUrl}/blog-post.html`);
-    
+
     if (!templateResponse.ok) {
       return new Response('Template not found', { status: 404 });
     }
-    
+
     let html = await templateResponse.text();
-    
+
     // Inject the slug into the HTML
     const slugScript = `<script>window.BLOG_SLUG = "${slug}";</script>`;
     html = html.replace('</head>', `${slugScript}</head>`);
-    
+
     return new Response(html, {
-      headers: { 
+      headers: {
         'Content-Type': 'text/html',
         'Cache-Control': 'public, max-age=300'
       }
     });
-    
+
   } catch (error) {
     console.error('Error in blog function:', error);
     return new Response('Server error', { status: 500 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "vibeagency",
+  "version": "1.0.0",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/tests/parseMarkdown.test.js
+++ b/tests/parseMarkdown.test.js
@@ -1,0 +1,28 @@
+const { parseMarkdown } = require('../blog');
+
+describe('parseMarkdown', () => {
+  test('parses front matter correctly', () => {
+    const md = `---
+    title: Test Post
+    date: 2024-06-05
+    featured_image: https://example.com/image.jpg
+    tags: tag1, tag2
+    draft: false
+    ---
+
+    This is the body of the post.`;
+
+    const post = parseMarkdown(md, 'test.md');
+
+    expect(post).toEqual({
+      slug: 'test',
+      title: 'Test Post',
+      date: '2024-06-05',
+      featured_image: 'https://example.com/image.jpg',
+      tags: ['tag1', 'tag2'],
+      draft: false,
+      body: 'This is the body of the post.',
+      excerpt: 'This is the body of the post....'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- export `parseMarkdown` from `blog.js`
- skip DOM behavior in Node environments
- handle `blog-index` slug in Cloudflare function
- add Node.js CI workflow
- add `parseMarkdown` Jest test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68414e6268f88327905c7ddbc4ef9c40